### PR TITLE
Bitemporal PCR tests data from Department of Health (via PR Public Health Trust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,8 @@ requiere Docker y Docker Compose. Desde este directorio:
 A Robby Cortés (@RobbyCortes en Twitter) y Angélica Serrano-Román
 (@angelicaserran0) que diligentemente publican los boletines del
 Departamento de Salud todas las mañanas.
+
+A Danilo Pérez por muchas sugerencias valiosas.
+
+Al Fideicomiso de Salud de Puerto Rico y al Prof. Rafael Irizarry
+por facilitar datos sobre pruebas moleculares en Puerto Rico.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ En el directorio [`assets/source_material/`](assets/source_material/)
 se recopilan imágenes de boletines y gráficas, según este esquema:
 
 * Archivos PDF originales de los informes en 
-  [`assets/source_materials/pdf/`](assets/source_materials/pdf/);
+  [`assets/source_material/pdf/`](assets/source_material/pdf/);
 * Archivos de imágenes extraídos de estos en directorios
-  fechados dentro de [`assets/source_materials/`](assets/source_materials/).
+  fechados dentro de [`assets/source_material/`](assets/source_material/).
 
 Una selección de datos de estos se ha copiado a mano a los archivos CSV 
 en el subdirectorio [`assets/data/`](assets/data/), que al momento consisten de:

--- a/postgres/010-schema.sql
+++ b/postgres/010-schema.sql
@@ -157,12 +157,55 @@ CREATE VIEW bioportal_bitemporal AS
 SELECT
     datum_date,
     bulletin_date,
-    count(*) positive_molecular_tests,
+    count(*) molecular_tests,
     count(*) FILTER (WHERE positive)
-        AS molecular_tests
+        AS positive_molecular_tests
 FROM bioportal_tests
 GROUP BY datum_date, bulletin_date;
 
+CREATE VIEW bioportal_bitemporal_agg AS
+WITH bulletin_dates AS (
+	SELECT DISTINCT bulletin_date
+	FROM bioportal_tests
+), dates AS (
+	SELECT DISTINCT datum_date
+	FROM bioportal_tests
+	WHERE '2020-03-01' <= datum_date
+	AND datum_date <= '2020-12-01'
+	UNION
+	SELECT DISTINCT datum_date
+	FROM bitemporal
+), grouped AS (
+	SELECT
+		bulletin_dates.bulletin_date,
+		dates.datum_date,
+		sum(molecular_tests)
+			AS molecular_tests,
+		sum(positive_molecular_tests)
+			AS positive_molecular_tests
+	FROM bulletin_dates
+	INNER JOIN dates
+		ON dates.datum_date <= bulletin_dates.bulletin_date
+	LEFT OUTER JOIN bioportal_bitemporal tests
+		ON tests.datum_date = dates.datum_date
+		AND tests.bulletin_date <= bulletin_dates.bulletin_date
+	GROUP BY dates.datum_date, bulletin_dates.bulletin_date
+	ORDER BY bulletin_dates.bulletin_date, dates.datum_date
+)
+SELECT
+	bulletin_date,
+	datum_date,
+	molecular_tests,
+	positive_molecular_tests,
+	sum(molecular_tests) OVER cumulative
+		AS cumulative_molecular_tests,
+	sum(positive_molecular_tests) OVER cumulative
+		AS cumulative_positive_molecular_tests
+FROM grouped
+WINDOW cumulative AS (
+	PARTITION BY bulletin_date
+	ORDER BY datum_date
+);
 
 CREATE TABLE hospitalizations (
     datum_date DATE,
@@ -311,32 +354,6 @@ COMMENT ON VIEW bitemporal_agg IS
 - Delta: Current bulletin_date''s value for current datum_date
   minus previous bulletin_date''s value for previous datum_date;
 - Lateness score: Delta * (bulletin_date - datum_date).';
-
-
-CREATE VIEW bioportal_bitemporal_agg AS
-SELECT
-    bulletin_date,
-    datum_date,
-
-    molecular_tests,
-    sum(molecular_tests) OVER bulletin
-        AS cumulative_molecular_tests,
-    molecular_tests - coalesce(lag(molecular_tests) OVER datum, 0)
-        AS delta_molecular_tests,
-    (molecular_tests - coalesce(lag(molecular_tests) OVER datum, 0))
-        * (bulletin_date - datum_date) AS lateness_molecular_tests,
-
-    positive_molecular_tests,
-    sum(positive_molecular_tests) OVER bulletin
-        AS cumulative_positive_molecular_tests,
-    positive_molecular_tests - coalesce(lag(positive_molecular_tests) OVER datum, 0)
-        AS delta_positive_molecular_tests,
-    (positive_molecular_tests - coalesce(lag(positive_molecular_tests) OVER datum, 0))
-        * (bulletin_date - datum_date) AS lateness_positive_molecular_tests
-FROM bioportal_bitemporal
-WINDOW
-    bulletin AS (PARTITION BY bulletin_date ORDER BY datum_date),
-    datum AS (PARTITION BY datum_date ORDER BY bulletin_date);
 
 
 CREATE VIEW announcement_consolidated AS
@@ -714,163 +731,32 @@ COMMENT ON VIEW products.doubling_times IS
 Computed over windows of 7, 14 and 21 days.';
 
 
-CREATE VIEW products.tests_by_bulletin_date AS
-WITH prdoh AS (
-	WITH bio_raw AS (
-		SELECT
-			b.bulletin_date,
-			b.bulletin_date - lag(b.bulletin_date) OVER bulletin
-				AS days,
-			b.cumulative_molecular_tests
-				AS cumulative_tests,
-			b.cumulative_positive_molecular_tests
-				AS cumulative_positive_tests,
-			a.cumulative_confirmed_cases
-				AS cumulative_cases,
-			b.new_molecular_tests
-				AS new_tests,
-			b.new_positive_molecular_tests
-				AS new_positive_tests,
-		    a.cumulative_confirmed_cases - lag(a.cumulative_confirmed_cases) OVER bulletin
-		        AS new_cases
-		FROM bioportal b
-		INNER JOIN announcement a
-			USING (bulletin_date)
-		WINDOW bulletin AS (ORDER BY b.bulletin_date)
-	)
-	SELECT
-		bulletin_date,
-		'Salud (moleculares)' AS source,
-		days AS days_since_last_report,
-		cumulative_tests,
-		cumulative_positive_tests,
-		cumulative_cases,
-		new_tests / days
-			AS smoothed_daily_tests,
-		new_positive_tests / days
-			AS smoothed_daily_positive_tests,
-		new_cases / days
-			AS smoothed_daily_cases
-	FROM bio_raw
-), serological AS (
-	WITH bio_raw AS (
-		SELECT
-			b.bulletin_date,
-			b.bulletin_date - lag(b.bulletin_date) OVER bulletin
-				AS days,
-			b.cumulative_serological_tests
-				AS cumulative_tests,
-			b.cumulative_positive_serological_tests
-				AS cumulative_positive_tests,
-			a.cumulative_probable_cases
-				AS cumulative_cases,
-			b.new_serological_tests
-				AS new_tests,
-			b.new_positive_serological_tests
-				AS new_positive_tests,
-		    a.cumulative_probable_cases - lag(a.cumulative_probable_cases) OVER bulletin
-		        AS new_cases
-		FROM bioportal b
-		INNER JOIN announcement a
-			USING (bulletin_date)
-		WINDOW bulletin AS (ORDER BY b.bulletin_date)
-	)
-	SELECT
-		bulletin_date,
-		'Salud (serológicas)' AS source,
-		days AS days_since_last_report,
-		cumulative_tests,
-		cumulative_positive_tests,
-		cumulative_cases,
-		new_tests / days
-			AS smoothed_daily_tests,
-		new_positive_tests / days
-			AS smoothed_daily_positive_tests,
-		new_cases / days
-			AS smoothed_daily_cases
-	FROM bio_raw
-), prpht AS (
-	WITH weekly_cumulatives AS (
-		SELECT
-			dates.bulletin_date :: date bulletin_date,
-			sum(delta_molecular_tests) cumulative_tests,
-			sum(delta_positive_molecular_tests) cumulative_positive_tests
-		FROM generate_series(date '2020-03-29',
-		   					 date '2020-06-28',
-		   					 INTERVAL '7 day')
-				AS dates (bulletin_date)
-		INNER JOIN prpht_molecular_deltas pmd
-			ON pmd.bulletin_date <= dates.bulletin_date
-		GROUP BY dates.bulletin_date
-		ORDER BY dates.bulletin_date
-	), weekly_deltas AS (
-		SELECT
-			bulletin_date,
-			cumulative_tests,
-			cumulative_tests
-				- lag(cumulative_tests) OVER prev
-				AS delta_tests,
-			cumulative_positive_tests,
-			cumulative_positive_tests
-				- lag(cumulative_positive_tests) OVER prev
-				AS delta_positive_tests
-		FROM weekly_cumulatives
-		WINDOW prev AS (ORDER BY bulletin_date)
-	)
-	SELECT
-		bulletin_date,
-		'PRPHT (moleculares)' source,
-		7 AS days_since_last_report,
-		cumulative_tests,
-		cumulative_positive_tests,
-		-- We omit this because it's not comparable with PRPHT data
-		NULL::BIGINT cumulative_cases,
-		delta_tests / 7.0
-			AS smoothed_daily_tests,
-		delta_positive_tests / 7.0
-			AS smoothed_daily_positive_tests,
-		-- We omit this because it's not comparable with PRPHT data
-		NULL::BIGINT smoothed_daily_confirmed_cases
-	FROM weekly_deltas wd
-	WINDOW prev AS (ORDER BY bulletin_date)
-)
-SELECT * FROM prdoh
-UNION
-SELECT * FROM serological
-UNION
-SELECT * FROM prpht
-ORDER BY bulletin_date, source;
-
-
 CREATE VIEW products.tests_by_datum_date AS
 SELECT
 	bulletin_date,
 	datum_date,
-	CAST(sum(tests.molecular_tests) OVER seven AS DOUBLE PRECISION)
-		/ sum(cases.confirmed_cases) OVER seven
-		AS new_tests_per_confirmed_case,
-	CAST(sum(tests.molecular_tests) OVER cumulative AS DOUBLE PRECISION)
-		/ sum(cases.confirmed_cases) OVER cumulative
-		AS cumulative_tests_per_confirmed_case,
-	(sum(tests.molecular_tests) OVER seven / 3193.694) / 7.0
-		AS new_daily_tests_per_thousand,
-	(sum(tests.molecular_tests) OVER cumulative / 3193.694)
-		AS cumulative_daily_tests_per_thousand
-FROM bitemporal_agg cases
-INNER JOIN bioportal_bitemporal_agg tests
-    USING (bulletin_date, datum_date)
-WINDOW
-	cumulative AS (
-		PARTITION BY bulletin_date
-		ORDER BY datum_date
-	),
-	seven AS (
-		PARTITION BY bulletin_date
-		ORDER BY datum_date
-		RANGE BETWEEN '6 days' PRECEDING AND CURRENT ROW
-	)
+	'Salud (moleculares)' source,
+	cumulative_molecular_tests AS cumulative_tests,
+	cumulative_positive_molecular_tests AS cumulative_positive_tests,
+	cumulative_confirmed_cases AS cumulative_cases,
+	sum(molecular_tests) OVER seven / 7.0
+		AS smoothed_daily_tests,
+	sum(positive_molecular_tests) OVER seven / 7.0
+		AS smoothed_daily_positive_tests,
+	(cumulative_confirmed_cases
+		- LAG(cumulative_confirmed_cases, 7, 0::bigint) OVER seven)
+		/ 7.0
+		AS smoothed_daily_cases
+FROM bioportal_bitemporal_agg tests
+INNER JOIN bitemporal_agg cases
+	USING (bulletin_date, datum_date)
+WHERE bulletin_date > '2020-04-24'
+WINDOW seven AS (
+	PARTITION BY bulletin_date
+	ORDER BY datum_date
+	RANGE '6 days' PRECEDING
+)
 ORDER BY bulletin_date, datum_date;
-
 
 CREATE VIEW products.municipal_map AS
 SELECT

--- a/postgres/010-schema.sql
+++ b/postgres/010-schema.sql
@@ -148,6 +148,7 @@ CREATE TABLE bioportal_tests (
     id BIGINT NOT NULL,
     datum_date DATE NOT NULL,
     bulletin_date DATE NOT NULL,
+    created_at TIMESTAMP,
     municipality TEXT,
     positive BOOLEAN NOT NULL,
     PRIMARY KEY (id)

--- a/postgres/020-load-data.sql
+++ b/postgres/020-load-data.sql
@@ -18,10 +18,6 @@ COPY bioportal
 FROM '/data/PuertoRico-bioportal.csv'
     CSV ENCODING 'UTF-8' HEADER NULL '';
 
-COPY bioportal_bitemporal
-FROM '/data/PuertoRico-bioportal-bitemporal.csv'
-    CSV ENCODING 'UTF-8' HEADER NULL '';
-
 COPY hospitalizations
 FROM '/data/PuertoRico-hospitalizations.csv'
     CSV ENCODING 'UTF-8' HEADER NULL '';
@@ -30,3 +26,38 @@ COPY prpht_molecular_raw
 FROM '/data/PRPHT-molecular.csv'
     CSV ENCODING 'UTF-8' HEADER NULL '';
 
+---------------------------------------------------------
+CREATE TEMPORARY TABLE bioportal_raw (
+    id BIGINT NOT NULL,
+    collectedDate DATE,
+    reportedDate DATE,
+    ageRange TEXT,
+    testType TEXT,
+    result TEXT,
+    patientCity TEXT,
+    createdAt TIMESTAMP WITHOUT TIME ZONE
+);
+
+COPY bioportal_raw
+FROM '/data/raw/bioportal.csv'
+    CSV ENCODING 'UTF-8' HEADER NULL '';
+
+INSERT INTO bioportal_tests
+SELECT
+    id,
+    collectedDate AS datum_date,
+    reportedDate AS bulletin_date,
+    CASE patientCity
+        WHEN 'Rio Grande' THEN 'Río Grande'
+        ELSE patientCity
+    END AS municipality,
+    COALESCE(result, '') LIKE '%Positive%'
+        AS positive
+FROM bioportal_raw
+WHERE collectedDate >= '2020-01-01'
+AND reportedDate >= '2020-03-13'
+AND testType = 'Molecular';
+
+CREATE INDEX ON bioportal_tests (datum_date, bulletin_date, municipality, positive);
+CREATE INDEX ON bioportal_tests (datum_date, municipality, positive);
+CREATE INDEX ON bioportal_tests (bulletin_date, municipality, positive);

--- a/src/covid_19_puerto_rico/__init__.py
+++ b/src/covid_19_puerto_rico/__init__.py
@@ -46,7 +46,6 @@ def main():
 
     targets = [
         molecular.DailyMissingTests(engine, args.output_dir, output_formats),
-        molecular.CumulativeMissingTests(engine, args.output_dir, output_formats),
         charts.Doubling(engine, args.output_dir, output_formats),
         charts.Hospitalizations(engine, args.output_dir, output_formats),
         molecular.CumulativeTestsVsCases(engine, args.output_dir, output_formats),

--- a/src/covid_19_puerto_rico/__init__.py
+++ b/src/covid_19_puerto_rico/__init__.py
@@ -45,6 +45,8 @@ def main():
         output_formats = frozenset(['json'])
 
     targets = [
+        molecular.DailyMissingTests(engine, args.output_dir, output_formats),
+        molecular.CumulativeMissingTests(engine, args.output_dir, output_formats),
         charts.Doubling(engine, args.output_dir, output_formats),
         charts.Hospitalizations(engine, args.output_dir, output_formats),
         molecular.CumulativeTestsVsCases(engine, args.output_dir, output_formats),

--- a/src/covid_19_puerto_rico/bioportal_xls.py
+++ b/src/covid_19_puerto_rico/bioportal_xls.py
@@ -1,0 +1,13 @@
+import pandas as pd
+
+def read_bioportal(path):
+    df = pd.read_excel(path)
+    df['collectedDate'] = pd.to_datetime(df['collectedDate'], format='%m/%d/%Y')
+    df['reportedDate'] = pd.to_datetime(df['reportedDate'], format='%m/%d/%Y', errors='coerce')
+    df['createdAt'] = pd.to_datetime(df['createdAt'], format='%m/%d/%Y %H:%M')
+    return df
+
+def write_bioportal(df, path):
+    df['collectedDate'] = df['collectedDate'].dt.strftime('%Y-%m-%d')
+    df['reportedDate'] = df['reportedDate'].dt.strftime('%Y-%m-%d')
+    df.to_csv(path, index_label='id')

--- a/src/covid_19_puerto_rico/molecular.py
+++ b/src/covid_19_puerto_rico/molecular.py
@@ -138,12 +138,16 @@ class AbstractPositiveRate(charts.AbstractChart):
              'PRPHT (moleculares)']
 
     def make_chart(self, df):
-        lines = alt.Chart(df.dropna()).mark_line(
+        lines = alt.Chart(df.dropna()).transform_filter(
+            alt.datum.value > 0.0
+        ).mark_line(
             point='transparent'
         ).encode(
             x=alt.X('datum_date:T', title='Puerto Rico',
                     axis=alt.Axis(format='%d/%m')),
-            y=alt.Y('value:Q', title=None, axis=alt.Axis(format='.2%')),
+            y=alt.Y('value:Q', title=None,
+                    scale=alt.Scale(type='log'),
+                    axis=alt.Axis(format='.2%')),
             color=alt.Color('Fuente:N', sort=self.ORDER,
                             legend=alt.Legend(orient='top', title=None, offset=0)),
             tooltip=[alt.Tooltip('datum_date:T', title='Fecha de muestra'),
@@ -151,11 +155,11 @@ class AbstractPositiveRate(charts.AbstractChart):
         )
 
         return lines.properties(
-            width=575, height=150
+            width=550, height=150
         ).facet(
             row=alt.Row('variable:N', title=None)
         ).resolve_scale(
-            y='independent'
+            y='shared'
         )
 
     def filter_data(self, df, bulletin_date):

--- a/src/covid_19_puerto_rico/molecular.py
+++ b/src/covid_19_puerto_rico/molecular.py
@@ -4,10 +4,9 @@
 #
 
 import altair as alt
-import datetime
 import pandas as pd
 import sqlalchemy
-from sqlalchemy import cast
+from sqlalchemy import cast, and_
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION
 from sqlalchemy.sql import select
 from . import charts
@@ -15,7 +14,9 @@ from . import charts
 
 class DailyMissingTests(charts.AbstractChart):
     def make_chart(self, df):
-        return alt.Chart(df).mark_bar().encode(
+        return alt.Chart(df).transform_calculate(
+            difference=alt.datum.positive_molecular_tests - alt.datum.confirmed_cases
+        ).mark_bar().encode(
             x=alt.X('yearmonthdate(datum_date):T',
                     title='Fecha de toma de muestra',
                     axis=alt.Axis(format='%d/%m')),
@@ -25,32 +26,46 @@ class DailyMissingTests(charts.AbstractChart):
                 alt.value('orange'),
                 alt.value('teal')
             ),
-            tooltip=['datum_date', 'difference:Q']
+            tooltip=[alt.Tooltip('datum_date:T', title='Fecha de toma de muestra'),
+                     alt.Tooltip('positive_molecular_tests:Q', title='Pruebas positivas'),
+                     alt.Tooltip('confirmed_cases:Q', title='Casos confirmados'),
+                     alt.Tooltip('difference:Q', title='Positivos menos confirmados')]
         ).properties(
             width=575, height=265
         )
 
     def fetch_data(self, connection):
         cases = sqlalchemy.Table('bitemporal', self.metadata, autoload=True)
-        tests = sqlalchemy.Table('bioportal_bitemporal', self.metadata, autoload=True)
+        tests = sqlalchemy.Table('bioportal_bitemporal_agg', self.metadata, autoload=True)
         query = select([
             cases.c.bulletin_date,
             cases.c.datum_date,
+            tests.c.positive_molecular_tests,
+            cases.c.confirmed_cases,
             (tests.c.positive_molecular_tests - cases.c.confirmed_cases).label('difference')
         ]).select_from(
-            tests.outerjoin(cases, tests.c.datum_date == cases.c.datum_date)
-        ).where(tests.c.bulletin_date == datetime.date(year=2020, month=5, day=20))
+            tests.outerjoin(
+                cases,
+                and_(tests.c.datum_date == cases.c.datum_date,
+                     tests.c.bulletin_date == cases.c.bulletin_date))
+        )
         return pd.read_sql_query(query, connection, parse_dates=["bulletin_date", "datum_date"])
 
 
 class CumulativeMissingTests(charts.AbstractChart):
     def make_chart(self, df):
-        return alt.Chart(df).mark_area(line=True, point=True).encode(
+        return alt.Chart(df).transform_calculate(
+            difference=alt.datum.cumulative_positive_molecular_tests \
+                        - alt.datum.cumulative_confirmed_cases
+        ).mark_area(opacity=0.8).encode(
             x=alt.X('yearmonthdate(datum_date):T',
                     title='Fecha de toma de muestra',
                     axis=alt.Axis(format='%d/%m')),
             y=alt.Y('difference:Q', title='Positivos menos confirmados'),
-            tooltip=['datum_date', 'difference:Q']
+            tooltip=[alt.Tooltip('datum_date:T', title='Fecha de toma de muestra'),
+                     alt.Tooltip('cumulative_positive_molecular_tests:Q', title='Pruebas positivas'),
+                     alt.Tooltip('cumulative_confirmed_cases:Q', title='Casos confirmados'),
+                     alt.Tooltip('difference:Q', title='Positivos menos confirmados')]
         ).properties(
             width=575, height=265
         )
@@ -61,75 +76,15 @@ class CumulativeMissingTests(charts.AbstractChart):
         query = select([
             cases.c.bulletin_date,
             cases.c.datum_date,
-            (tests.c.cumulative_positive_molecular_tests - cases.c.cumulative_confirmed_cases)\
-                .label('difference')
+            tests.c.cumulative_positive_molecular_tests,
+            cases.c.cumulative_confirmed_cases
         ]).select_from(
-            tests.outerjoin(cases, tests.c.datum_date == cases.c.datum_date)
-        ).where(tests.c.bulletin_date == datetime.date(year=2020, month=5, day=20))
+            tests.outerjoin(
+                cases,
+                and_(tests.c.datum_date == cases.c.datum_date,
+                     tests.c.bulletin_date == cases.c.bulletin_date))
+        )
         return pd.read_sql_query(query, connection, parse_dates=["bulletin_date", "datum_date"]).dropna()
-
-
-class TestsBySampleDate(charts.AbstractChart):
-    def make_chart(self, df):
-        data_date = alt.Chart(df).mark_text(baseline='middle').encode(
-            text=alt.Text('bulletin_date',
-                          type='temporal',
-                          aggregate='max',
-                          timeUnit='yearmonthdate',
-                          format='Datos hasta: %d de %B, %Y'),
-        ).properties(
-            width=575, height=40
-        )
-
-        sort_order = [
-            'Pruebas nuevas por caso confirmado',
-            'Pruebas acumuladas por caso confirmado (promedio 7 días)'
-            'Pruebas nuevas diarias por mil habitantes (promedio 7 días)',
-            'Pruebas acumuladas diarias por mil habitantes',
-        ]
-        trellis = alt.Chart(df).mark_line(point=True).encode(
-            x=alt.X('yearmonthdate(datum_date):T',
-                    title='Fecha de toma de muestra',
-                    axis=alt.Axis(format='%d/%m')),
-            y=alt.Y('value:Q', title=None, scale=alt.Scale(type='linear')),
-            tooltip=[alt.Tooltip('datum_date:T', title='Fecha de muestra'),
-                     alt.Tooltip('variable:N', title='Variable'),
-                     alt.Tooltip(field='value:Q', format=".2f", title='Pruebas')]
-        ).properties(
-            width=575, height=100
-        ).facet(
-            columns=1,
-            facet=alt.Facet('variable', title=None, sort=sort_order)
-        ).resolve_scale(
-            y='independent'
-        )
-
-        return alt.vconcat(data_date, trellis)
-
-    def fetch_data(self, connection):
-        table = sqlalchemy.Table('tests_by_sample_date', self.metadata,
-                                 schema='products', autoload=True)
-        query = select([
-            table.c.bulletin_date,
-            table.c.datum_date,
-            table.c.new_tests_per_confirmed_case,
-            table.c.cumulative_tests_per_confirmed_case,
-            table.c.new_daily_tests_per_thousand,
-            table.c.cumulative_daily_tests_per_thousand,
-        ])
-        df = pd.read_sql_query(query, connection, parse_dates=['bulletin_date', 'datum_date'])
-        df = df.rename(columns={
-            'new_tests_per_confirmed_case': 'Pruebas nuevas por caso confirmado  (promedio 7 días)',
-            'cumulative_tests_per_confirmed_case': 'Pruebas acumuladas por caso confirmado',
-            'new_daily_tests_per_thousand': 'Pruebas nuevas diarias por mil habitantes (promedio 7 días)',
-            'cumulative_daily_tests_per_thousand': 'Pruebas acumuladas diarias por mil habitantes',
-        })
-        return pd.melt(df, ['bulletin_date', 'datum_date'])
-
-    def filter_data(self, df, bulletin_date):
-        chopped = df.loc[df['bulletin_date'] <= pd.to_datetime(bulletin_date)]
-        max_date = chopped['bulletin_date'].max()
-        return df.loc[df['bulletin_date'] == max_date]
 
 
 class AbstractPositiveRate(charts.AbstractChart):
@@ -161,9 +116,6 @@ class AbstractPositiveRate(charts.AbstractChart):
         ).resolve_scale(
             y='shared'
         )
-
-    def filter_data(self, df, bulletin_date):
-        return df.loc[df['bulletin_date'] == pd.to_datetime(bulletin_date)]
 
 
 class NewPositiveRate(AbstractPositiveRate):
@@ -229,9 +181,6 @@ class AbstractPerCapitaChart(charts.AbstractChart):
             width=600, height=125
         )
 
-    def filter_data(self, df, bulletin_date):
-        return df.loc[df['bulletin_date'] == pd.to_datetime(bulletin_date)]
-
 
 class NewDailyTestsPerCapita(AbstractPerCapitaChart):
     def fetch_data(self, connection):
@@ -274,9 +223,6 @@ class CumulativeTestsVsCases(charts.AbstractChart):
             table.c.cumulative_cases
         ])
         return pd.read_sql_query(query, connection, parse_dates=['bulletin_date', 'datum_date'])
-
-    def filter_data(self, df, bulletin_date):
-        return df.loc[df['bulletin_date'] == pd.to_datetime(bulletin_date)]
 
     def make_chart(self, df):
         max_x, max_y = 2_600, 100_000

--- a/src/covid_19_puerto_rico/molecular.py
+++ b/src/covid_19_puerto_rico/molecular.py
@@ -139,14 +139,14 @@ class AbstractPositiveRate(charts.AbstractChart):
 
     def make_chart(self, df):
         lines = alt.Chart(df.dropna()).mark_line(
-            point=True
+            point='transparent'
         ).encode(
-            x=alt.X('bulletin_date:T', title='Puerto Rico',
+            x=alt.X('datum_date:T', title='Puerto Rico',
                     axis=alt.Axis(format='%d/%m')),
             y=alt.Y('value:Q', title=None, axis=alt.Axis(format='.2%')),
             color=alt.Color('Fuente:N', sort=self.ORDER,
                             legend=alt.Legend(orient='top', title=None, offset=0)),
-            tooltip=[alt.Tooltip('bulletin_date:T', title='Fecha de boletín'),
+            tooltip=[alt.Tooltip('datum_date:T', title='Fecha de muestra'),
                      alt.Tooltip('value:Q', format=".2%", title='Tasa de positividad')]
         )
 
@@ -159,32 +159,34 @@ class AbstractPositiveRate(charts.AbstractChart):
         )
 
     def filter_data(self, df, bulletin_date):
-        return df.loc[df['bulletin_date'] <= pd.to_datetime(bulletin_date)]
+        return df.loc[df['bulletin_date'] == pd.to_datetime(bulletin_date)]
 
 
 class NewPositiveRate(AbstractPositiveRate):
     def fetch_data(self, connection):
-        table = sqlalchemy.Table('tests_by_bulletin_date', self.metadata,
+        table = sqlalchemy.Table('tests_by_datum_date', self.metadata,
                                  schema='products', autoload=True)
         query = select([
             table.c.source.label('Fuente'),
             table.c.bulletin_date,
+            table.c.datum_date,
             (table.c.smoothed_daily_positive_tests / table.c.smoothed_daily_tests)\
                 .label('Positivas / pruebas'),
             (table.c.smoothed_daily_cases / table.c.smoothed_daily_tests)\
                 .label('Casos / pruebas')
         ])
-        df = pd.read_sql_query(query, connection, parse_dates=['bulletin_date'])
-        return pd.melt(df, ['Fuente', 'bulletin_date'])
+        df = pd.read_sql_query(query, connection, parse_dates=['bulletin_date', 'datum_date'])
+        return pd.melt(df, ['Fuente', 'bulletin_date', 'datum_date'])
 
 
 class CumulativePositiveRate(AbstractPositiveRate):
     def fetch_data(self, connection):
-        table = sqlalchemy.Table('tests_by_bulletin_date', self.metadata,
+        table = sqlalchemy.Table('tests_by_datum_date', self.metadata,
                                  schema='products', autoload=True)
         query = select([
             table.c.source.label('Fuente'),
             table.c.bulletin_date,
+            table.c.datum_date,
             (cast(table.c.cumulative_positive_tests, DOUBLE_PRECISION)
                 / table.c.cumulative_tests)\
                 .label('Positivas / pruebas'),
@@ -192,8 +194,8 @@ class CumulativePositiveRate(AbstractPositiveRate):
                   / table.c.cumulative_tests)\
                 .label('Casos / pruebas')
         ])
-        df = pd.read_sql_query(query, connection, parse_dates=['bulletin_date'])
-        return pd.melt(df, ['Fuente', 'bulletin_date'])
+        df = pd.read_sql_query(query, connection, parse_dates=['bulletin_date', 'datum_date'])
+        return pd.melt(df, ['Fuente', 'bulletin_date', 'datum_date'])
 
 
 
@@ -209,14 +211,14 @@ class AbstractPerCapitaChart(charts.AbstractChart):
         return alt.Chart(df.dropna()).transform_calculate(
             per_thousand=alt.datum.value / self.POPULATION_THOUSANDS
         ).mark_line(
-            point=True
+            point='transparent'
         ).encode(
-            x=alt.X('bulletin_date:T', title='Puerto Rico',
+            x=alt.X('datum_date:T', title='Puerto Rico',
                     axis=alt.Axis(format='%d/%m')),
             y=alt.Y('per_thousand:Q', title=None),
             color=alt.Color('Fuente:N', sort=self.ORDER,
                             legend=alt.Legend(orient='top', title=None)),
-            tooltip=[alt.Tooltip('bulletin_date:T', title='Fecha de boletín'),
+            tooltip=[alt.Tooltip('datum_date:T', title='Fecha de muestra'),
                      alt.Tooltip('per_thousand:Q', format=".2f",
                                  title='Pruebas por mil habitantes')]
         ).properties(
@@ -224,30 +226,32 @@ class AbstractPerCapitaChart(charts.AbstractChart):
         )
 
     def filter_data(self, df, bulletin_date):
-        return df.loc[df['bulletin_date'] <= pd.to_datetime(bulletin_date)]
+        return df.loc[df['bulletin_date'] == pd.to_datetime(bulletin_date)]
 
 
 class NewDailyTestsPerCapita(AbstractPerCapitaChart):
     def fetch_data(self, connection):
-        table = sqlalchemy.Table('tests_by_bulletin_date', self.metadata,
+        table = sqlalchemy.Table('tests_by_datum_date', self.metadata,
                                  schema='products', autoload=True)
         query = select([
             table.c.source.label('Fuente'),
             table.c.bulletin_date,
+            table.c.datum_date,
             table.c.smoothed_daily_tests.label('value')
         ])
-        return pd.read_sql_query(query, connection, parse_dates=["bulletin_date"])
+        return pd.read_sql_query(query, connection, parse_dates=["bulletin_date", "datum_date"])
 
 class CumulativeTestsPerCapita(AbstractPerCapitaChart):
     def fetch_data(self, connection):
-        table = sqlalchemy.Table('tests_by_bulletin_date', self.metadata,
+        table = sqlalchemy.Table('tests_by_datum_date', self.metadata,
                                  schema='products', autoload=True)
         query = select([
             table.c.source.label('Fuente'),
             table.c.bulletin_date,
+            table.c.datum_date,
             table.c.cumulative_tests.label('value')
         ])
-        return pd.read_sql_query(query, connection, parse_dates=["bulletin_date"])
+        return pd.read_sql_query(query, connection, parse_dates=["bulletin_date", "datum_date"])
 
 
 class CumulativeTestsVsCases(charts.AbstractChart):
@@ -256,18 +260,19 @@ class CumulativeTestsVsCases(charts.AbstractChart):
              'Salud (serológicas)']
 
     def fetch_data(self, connection):
-        table = sqlalchemy.Table('tests_by_bulletin_date', self.metadata,
+        table = sqlalchemy.Table('tests_by_datum_date', self.metadata,
                                  schema='products', autoload=True)
         query = select([
             table.c.bulletin_date,
+            table.c.datum_date,
             table.c.source.label('Fuente'),
             table.c.cumulative_tests,
             table.c.cumulative_cases
         ])
-        return pd.read_sql_query(query, connection, parse_dates=['bulletin_date'])
+        return pd.read_sql_query(query, connection, parse_dates=['bulletin_date', 'datum_date'])
 
     def filter_data(self, df, bulletin_date):
-        return df.loc[df['bulletin_date'] <= pd.to_datetime(bulletin_date)]
+        return df.loc[df['bulletin_date'] == pd.to_datetime(bulletin_date)]
 
     def make_chart(self, df):
         max_x, max_y = 2_600, 100_000
@@ -276,15 +281,15 @@ class CumulativeTestsVsCases(charts.AbstractChart):
             tests_per_million=alt.datum.cumulative_tests / self.POPULATION_MILLIONS,
             cases_per_million=alt.datum.cumulative_cases / self.POPULATION_MILLIONS,
             positive_rate=alt.datum.cumulative_cases / alt.datum.cumulative_tests
-        ).mark_line(point=True).encode(
+        ).mark_line(point='transparent').encode(
             y=alt.Y('tests_per_million:Q', scale=alt.Scale(domain=[0, max_y]),
                     title='Total de pruebas por millón de habitantes'),
             x=alt.X('cases_per_million:Q', scale=alt.Scale(domain=[0, max_x]),
                     title='Total de casos por millón de habitantes'),
-            order=alt.Order('bulletin_date:T'),
+            order=alt.Order('datum_date:T'),
             color=alt.Color('Fuente:N', sort=self.ORDER,
                             legend=alt.Legend(orient='top', title=None, offset=25)),
-            tooltip=[alt.Tooltip('yearmonthdate(bulletin_date):T', title='Fecha de boletín'),
+            tooltip=[alt.Tooltip('yearmonthdate(datum_date):T', title='Fecha de muestra'),
                      alt.Tooltip('Fuente:N'),
                      alt.Tooltip('tests_per_million:Q', format=",d",
                                  title='Pruebas por millón de habitantes'),

--- a/src/covid_19_puerto_rico/molecular.py
+++ b/src/covid_19_puerto_rico/molecular.py
@@ -51,6 +51,11 @@ class DailyMissingTests(charts.AbstractChart):
         )
         return pd.read_sql_query(query, connection, parse_dates=["bulletin_date", "datum_date"])
 
+    def filter_data(self, df, bulletin_date):
+        effective_bulletin_date = min(df['bulletin_date'].max(), pd.to_datetime(bulletin_date))
+        return df.loc[df['bulletin_date'] == effective_bulletin_date]
+
+
 
 class CumulativeMissingTests(charts.AbstractChart):
     def make_chart(self, df):
@@ -86,6 +91,10 @@ class CumulativeMissingTests(charts.AbstractChart):
         )
         return pd.read_sql_query(query, connection, parse_dates=["bulletin_date", "datum_date"]).dropna()
 
+    def filter_data(self, df, bulletin_date):
+        effective_bulletin_date = min(df['bulletin_date'].max(), pd.to_datetime(bulletin_date))
+        return df.loc[df['bulletin_date'] == effective_bulletin_date]
+
 
 class AbstractPositiveRate(charts.AbstractChart):
     ORDER = ['Salud (moleculares)',
@@ -116,6 +125,10 @@ class AbstractPositiveRate(charts.AbstractChart):
         ).resolve_scale(
             y='shared'
         )
+
+    def filter_data(self, df, bulletin_date):
+        effective_bulletin_date = min(df['bulletin_date'].max(), pd.to_datetime(bulletin_date))
+        return df.loc[df['bulletin_date'] == effective_bulletin_date]
 
 
 class NewPositiveRate(AbstractPositiveRate):
@@ -181,6 +194,10 @@ class AbstractPerCapitaChart(charts.AbstractChart):
             width=600, height=125
         )
 
+    def filter_data(self, df, bulletin_date):
+        effective_bulletin_date = min(df['bulletin_date'].max(), pd.to_datetime(bulletin_date))
+        return df.loc[df['bulletin_date'] == effective_bulletin_date]
+
 
 class NewDailyTestsPerCapita(AbstractPerCapitaChart):
     def fetch_data(self, connection):
@@ -223,6 +240,10 @@ class CumulativeTestsVsCases(charts.AbstractChart):
             table.c.cumulative_cases
         ])
         return pd.read_sql_query(query, connection, parse_dates=['bulletin_date', 'datum_date'])
+
+    def filter_data(self, df, bulletin_date):
+        effective_bulletin_date = min(df['bulletin_date'].max(), pd.to_datetime(bulletin_date))
+        return df.loc[df['bulletin_date'] == effective_bulletin_date]
 
     def make_chart(self, df):
         max_x, max_y = 2_600, 100_000

--- a/src/covid_19_puerto_rico/templates/bulletin_date_index.html
+++ b/src/covid_19_puerto_rico/templates/bulletin_date_index.html
@@ -45,7 +45,6 @@
         <li><a href="#NewDailyTestsPerCapita_section">Pruebas nuevas por mil habitantes, promedio diario</a></li>
         <li><a href="#CumulativeTestsPerCapita_section">Pruebas acumuladas por mil habitantes</a></li>
         <li><a href="#DailyMissingTests_section">Pruebas duplicadas y perdidas diarias</a></li>
-        <li><a href="#CumulativeMissingTests_section">Pruebas duplicadas y perdidas acumuladas</a></li>
         <li><a href="#ConsecutiveBulletinMismatch_section">Descuadre de encabezado de boletín</a></li>
         <li><a href="#BulletinChartMismatch_section">Descuadre de boletín y gráficas</a></li>
         <li><a href="#Terminology_section">Terminología</a></li>
@@ -535,21 +534,6 @@
 
     <p>Nótese también que los datos sobre pruebas son del 20 de mayo porque esos
         son los únicos que Salud ha publicado al momento.</p>
-</div>
-
-
-<div class="section" id="CumulativeMissingTests_section">
-    <h1>Pruebas duplicadas y perdidas acumuladas</h1>
-
-    <div id="CumulativeMissingTests"></div>
-    <script type="text/javascript">
-        embedChart('CumulativeMissingTests', bulletin_date);
-    </script>
-
-    <h3>¿Qué es esto?</h3>
-
-    <p>El mismo análisis de "pruebas perdidas" que el anterior pero con números
-        acumulados en vez de diarios.</p>
 </div>
 
 

--- a/src/covid_19_puerto_rico/templates/bulletin_date_index.html
+++ b/src/covid_19_puerto_rico/templates/bulletin_date_index.html
@@ -44,6 +44,8 @@
         <li><a href="#CumulativeTestsVsCases_section">Pruebas vs. casos (acumulado)</a></li>
         <li><a href="#NewDailyTestsPerCapita_section">Pruebas nuevas por mil habitantes, promedio diario</a></li>
         <li><a href="#CumulativeTestsPerCapita_section">Pruebas acumuladas por mil habitantes</a></li>
+        <li><a href="#DailyMissingTests_section">Pruebas duplicadas y perdidas diarias</a></li>
+        <li><a href="#CumulativeMissingTests_section">Pruebas duplicadas y perdidas acumuladas</a></li>
         <li><a href="#ConsecutiveBulletinMismatch_section">Descuadre de encabezado de boletín</a></li>
         <li><a href="#BulletinChartMismatch_section">Descuadre de boletín y gráficas</a></li>
         <li><a href="#Terminology_section">Terminología</a></li>
@@ -496,6 +498,58 @@
 
     <p>Cuántas pruebas moleculares se han administrado cumulativamente, divido por millares
         de población, acompañado de comparación internacional.</p>
+</div>
+
+
+<div class="section" id="DailyMissingTests_section">
+    <h1>Pruebas duplicadas y perdidas diarias</h1>
+
+    <div id="DailyMissingTests"></div>
+    <script type="text/javascript">
+        embedChart('DailyMissingTests', bulletin_date);
+    </script>
+
+    <h3>¿Qué es esto?</h3>
+
+    <p>La resta, por cada fecha de muestra, de:</p>
+    <ol>
+        <li>El número de casos confirmados (por prueba molecular) no duplicados
+            que el boletín le atribuye a esa fecha de muestra;</li>
+        <li>El número de pruebas positivas que la gráfica con datos <b>hasta
+            el 20 de mayo solamente</b> le atribuye a esa fecha de muestra.</li>
+    </ol>
+
+    <p>Ninguna de estas restas se supone que sea menos que cero, porque si has
+        confirmado tantos casos por prueba molecular tomada en tal fecha, se supone
+        que tengas por lo menos la misma cantidad de pruebas positivas tomadas
+        en esa misma fecha.  Pero se vé que no es así en estos datos.  Las fechas
+        que dan negativo las llamo <b>pruebas perdidas</b>—casos confirmados no
+        duplicados que se han reportado pero cuyas pruebas confirmatorias, a primera
+        vista, no parecen haberse contado.</p>
+
+    <p>Nótese que esto no es un procedimiento que de respuestas exactas, y puede
+        por ejemplo que una de las pruebas en exceso en fechas posteriores sea de
+        alguno de los pacientes que más temprano aparece como prueba "perdida."
+        El llamarlo "prueba perdida" no es un diagnóstico de la causa del descuadre,
+        sino una puyita para llamar la atención a este.</p>
+
+    <p>Nótese también que los datos sobre pruebas son del 20 de mayo porque esos
+        son los únicos que Salud ha publicado al momento.</p>
+</div>
+
+
+<div class="section" id="CumulativeMissingTests_section">
+    <h1>Pruebas duplicadas y perdidas acumuladas</h1>
+
+    <div id="CumulativeMissingTests"></div>
+    <script type="text/javascript">
+        embedChart('CumulativeMissingTests', bulletin_date);
+    </script>
+
+    <h3>¿Qué es esto?</h3>
+
+    <p>El mismo análisis de "pruebas perdidas" que el anterior pero con números
+        acumulados en vez de diarios.</p>
 </div>
 
 

--- a/src/covid_19_puerto_rico/templates/bulletin_date_index.html
+++ b/src/covid_19_puerto_rico/templates/bulletin_date_index.html
@@ -380,68 +380,39 @@
 
     <h3>¿Qué es esto?</h3>
 
-    <p>Las tasas de positividad de según los datos del Departamento de Salud, usando tanto
-        el más reciente informe de pruebas moleculares reportadas por laboratorios a su Bio
-        Portal, como el número de casos confirmados reportados hasta la misma fecha. Se
-        acompaña con gráfica de <a href="https://ourworldindata.org/">Our World in Data</a>
+    <p>La tasa de positividad por fecha de toma de muestra, según datos que ha compartido el
+        Departamento de Salud de Puerto Rico con el Fideicomiso de Salud Pública de Puerto Rico.
+        Se acompaña con gráfica de <a href="https://ourworldindata.org/">Our World in Data</a>
         para poner estas cifras en contexto internacional.</p>
 
-    <p>Se calcula esta cifra aquí de dos maneras distintas:</p>
+    <p>Se calcula aquí la tasa de positividad de dos maneras distintas:</p>
 
     <ol>
         <li>Número de pruebas positivas dividido entre número total de pruebas;</li>
-        <li>Número de casos únicos confirmados dividido entre número total de pruebas.</li>
+        <li>Número de casos únicos confirmados (tomado de los informes regulares de Salud)
+            dividido entre número total de pruebas.</li>
     </ol>
 
     <p>La segunda de estas se entiende que es una división un tanto de "chinas con botellas"
         (i.e., cantidades que en realidad no deberían compararse), pero se ha optado por
-        incluirla por dos motivos prácticos:</p>
+        incluirla porque muchas colecciones de datos en EEUU (e.g., COVID Tracking Project)
+        e internacionales (e.g., Our World In Data) así lo calculan para muchos locales.
+        Lo cual quiere decir que a la hora de comparar el dato de Puerto Rico con el de otro
+        país hay que tener cuidado cuál de las dos se habla.</p>
+
+    <p>Otra advertencia es que el cálculo dado aquí para Puerto Rico hace uso de datos por
+        fecha de toma de muestra, y no de reporte de resultados como hacen muchas colecciones
+        de datos o informes.  Esto da números que reflejan la realidad más cercanamente, pero
+        acarrea dos desventajas:</p>
 
     <ol>
-        <li>Hay varios indicios de que el conteo de casos únicos del Departamento de Salud de
-            Puerto Rico produce resultados más adelantados que el conteo bruto de pruebas
-            positivas, y que por lo tanto la tasa de "chinas con botellas" dará alerta más
-            temprano si se deteriora la situación;</li>
-        <li>Muchas colecciones de datos internacionales (como la incluída de Our World in Data)
-            hacen el cálculo de "chinas con botellas" para muchos países por falta de mejores
-            datos.</li>
+        <li>Las cifras dadas para cualquier fecha no son finales, porque mañana pueden recibirse
+            nuevos resultados de muestras tomadas en esas mismas fechas, y que llevarán
+            a que se revisen los valores aquí calculados;</li>
+        <li>Un caso especial muy importante de esto es que caídas o subidas repentinas al final
+            de la curva no son fiables, porque para las fechas más recientes se espera que se
+            incorpore una mayor proporción de nuevos resultados.</li>
     </ol>
-
-    <p>No obstante lo anterior, no se calcula casos únicos / pruebas con datos del Fideicomiso
-        de Salud (PRPHT), por entenderse (a partir de información examinada) que el numerador
-        de esta división contiene muchos casos cuyas pruebas no se incluyen en el denominador,
-        ya que Salud no reporta pruebas de su laboratorio al Fideicomiso y entre estas parecen
-        haber cientos de resultados positivos.</p>
-
-    <h3>Advertencias</h3>
-
-    <p>El Departamento de Salud solo ha publicado el informe de Bioportal irregular e
-        infrecuentemente, y existen serias dudas sobre la calidad de los datos de su
-        conteo de pruebas.  Sin embargo esas dudas parecen apuntar a:</p>
-
-    <ol>
-        <li>Un subconteo general de las pruebas moleculares (se han hecho muchas más pruebas
-            de las que reporta Salud);</li>
-        <li>Prioridad en el conteo de pruebas positivas y nuevos casos únicos por encima del
-            conteo de las pruebas negativas y por tanto los totales de pruebas.</li>
-    </ol>
-
-    <p>Si entendemos así, entonces:</p>
-
-    <ol>
-        <li>Los números verdaderos de pruebas por 1,000 habitantes serían en realidad mayores
-            a los aquí calculados, porque el número de pruebas es el numerador y el denominador
-            se queda igual;</li>
-        <li>Las verdaderas tasas de positividad se esperaría que fueran semejantes o menores a
-            las aquí calculadas, suponiendo o bien que las pruebas contabilizadas son una muestra
-            representativa de las realizadas, o que si existe sesgo este es a favor de contabilizar
-            pruebas positivas y casos.</li>
-    </ol>
-
-    <p>En adición a esto, hay que advertir que este cálculo se realiza a partir de las fechas
-        que se anunciaron las pruebas y los casos, no las fechas que se tomaron las muestras.
-        Y esto pudiera cobrar mayor importancia por el serio rezago con que aparentan
-        contarse las pruebas.</p>
 </div>
 
 
@@ -461,7 +432,7 @@
     <h3>¿Qué es esto?</h3>
 
     <p>El mismo cálculo de tasa de positividad que arriba, pero con cifras
-        acumuladas en vez de nuevas.  Las mismas advertencias aplican.</p>
+        acumuladas en vez de nuevas.</p>
 </div>
 
 
@@ -504,11 +475,10 @@
 
     <h3>¿Qué es esto?</h3>
 
-    <p>Cuántas pruebas diarias promedio se realizaron entre informes del Bioportal, por millar
-        de población.  Se presenta una gráfica de Our World in Data para comparación, pero
-        <b>advertencia</b>, OWID usa promedios rodantes de siete días, y nuestro cálculo aquí
-        es a partir de periodos irregulares entre los informes de Bioportal.</p>
+    <p>Cuántas pruebas diarias (promedio de 7 días) se realizaron por fecha de toma de muestra,
+        por millar de población.  Se presenta una gráfica de Our World in Data para comparación.</p>
 </div>
+
 
 <div class="section" id="CumulativeTestsPerCapita_section">
     <h1>Pruebas acumuladas por mil habitantes</h1>


### PR DESCRIPTION
The Puerto Rico Public Health Trust and Dr. Rafael Irizarry have worked with the Department of Health to obtain a testing data set with sample collection date and report date in it, which may be found (in Excel format) in here:

* https://github.com/rafalab/pr-covid

I've converted that into a CSV (manually), checked it in a revamped a number of charts to use that.