### PR TITLE
LatenessTiers chart

### DIFF
--- a/postgres/010-schema.sql
+++ b/postgres/010-schema.sql
@@ -661,6 +661,25 @@ INNER JOIN canonical_municipal_names cmn
 ORDER BY municipality, bulletin_date;
 
 
+CREATE VIEW products.lateness_tiers AS
+SELECT
+	bulletin_date,
+	ranges.tier,
+	ranges.lo AS tier_order,
+	COALESCE(sum(delta_confirmed_cases) FILTER (
+		WHERE delta_confirmed_cases > 0
+	), 0) AS count
+FROM bitemporal_agg ba
+INNER JOIN (VALUES (0, 3, '0-3'),
+				   (4, 7, '4-7'),
+				   (8, 14, '8-14'),
+				   (14, NULL, '> 14')) AS ranges (lo, hi, tier)
+	ON ranges.lo <= age AND age <= COALESCE(ranges.hi, 2147483647)
+WHERE bulletin_date > '2020-04-24'
+GROUP BY bulletin_date, ranges.lo, ranges.hi, ranges.tier
+ORDER BY bulletin_date DESC, ranges.lo ASC;
+
+
 CREATE VIEW products.lateness_tiers_smoothed AS
 WITH min_date AS (
 	SELECT min(bulletin_date) min_bulletin_date

--- a/postgres/020-load-data.sql
+++ b/postgres/020-load-data.sql
@@ -6,6 +6,8 @@ COPY bitemporal
 FROM '/data/cases/PuertoRico-bitemporal.csv'
     CSV ENCODING 'UTF-8' HEADER NULL '';
 ANALYZE VERBOSE bitemporal;
+REFRESH MATERIALIZED VIEW bitemporal_agg;
+ANALYZE VERBOSE bitemporal_agg;
 
 COPY canonical_municipal_names
 FROM '/data/cases/Municipalities-canonical_names.csv'
@@ -29,8 +31,4 @@ FROM '/data/cases/PuertoRico-bioportal.csv'
 
 COPY hospitalizations
 FROM '/data/cases/PuertoRico-hospitalizations.csv'
-    CSV ENCODING 'UTF-8' HEADER NULL '';
-
-COPY prpht_molecular_raw
-FROM '/data/cases/PRPHT-molecular.csv'
     CSV ENCODING 'UTF-8' HEADER NULL '';

--- a/src/covid_19_puerto_rico/__init__.py
+++ b/src/covid_19_puerto_rico/__init__.py
@@ -45,6 +45,7 @@ def main():
         output_formats = frozenset(['json'])
 
     targets = [
+        charts.LatenessTiers(engine, args.output_dir, output_formats),
         molecular.TestingLoad(engine, args.output_dir, output_formats),
         charts.HospitalizationsCovid19Tracking(engine, args.output_dir, output_formats),
         molecular.NewPositiveRate(engine, args.output_dir, output_formats),

--- a/src/covid_19_puerto_rico/templates/bulletin_date_index.html
+++ b/src/covid_19_puerto_rico/templates/bulletin_date_index.html
@@ -33,6 +33,7 @@
         <li><a href="#DailyDeltas_section">Cambios entre boletines recientes</a></li>
         <li><a href="#LatenessDaily_section">Rezago de datos de cada boletín</a></li>
         <li><a href="#Lateness7Day_section">Tendencia de rezago de datos</a></li>
+        <li><a href="#LatenessTiers_section">Historial de rezagos por renglones</a></li>
         <li><a href="#NewDailyTestsPerCapita_section">Pruebas per cápita (promedio 7 días)</a></li>
         <li><a href="#TestingLoad_section">Carga de pruebas de seguimiento</a></li>
         <li><a href="#NewPositiveRate_section">Positividad (promedio 7 días)</a></li>
@@ -215,6 +216,28 @@
         <li><a href="#Revisions_2020-07-03">3 de julio del 2020</a></li>
         <li><a href="#Revisions_2020-06-05">5 de junio del 2020</a></li>
     </ul>
+</div>
+
+
+<div class="section" id="LatenessTiers_section">
+    <h1>Historial de rezagos por renglones</h1>
+
+    <div id="LatenessTiers" class="chart"></div>
+    <script type="text/javascript">
+      embedChart('LatenessTiers', bulletin_date);
+    </script>
+
+    <h3>¿Qué es esto?</h3>
+
+    <p>Una gráfica de dos paneles que muestra promedios de siete días de casos confirmados
+        nuevos, por fecha de boletín (¡no de muestra!), divididos en renglones de rezago
+        (tiempo entre toma de muestra e incorporación en el conteo).  El panel superior muestra
+        los volúmenes absolutos; el panel inferior es los mismos datos, pero en porcentajes.</p>
+
+    <p>La forma de la curva superior se parece una gráfica de casos nuevos por fecha que se
+        incorporan al conteo, pero <strong>alerta</strong>, no cuenta muchas <em>restas</em> de
+        casos al conteo (porque las restas dañan los estimados de rezagos, hacen que den negativo).
+        Por esto la curva es en realidad más alta que los números verdaderos de casos confirmados.</p>
 </div>
 
 


### PR DESCRIPTION
Adds a chart that views case reporting lag in terms of counts of different tiers instead of an average lag like the ones we have now. The average lag looks simple but doesn't give a good sense of the distribution of values.