### PR TITLE
Backend for improved followups/reinfections analysis

### DIFF
--- a/aws/athena-dbt/analysis/reinfections/analisis_recontagios.sql
+++ b/aws/athena-dbt/analysis/reinfections/analisis_recontagios.sql
@@ -1,0 +1,36 @@
+--
+-- Análisis de recontagios.  Comparación de conteo oficial con
+-- mi análisis que toma en cuenta posibles recontagios.
+--
+WITH bulletins AS (
+	SELECT max(bulletin_date) AS bulletin_date
+	FROM covid19_puerto_rico_model.bioportal_curve
+)
+SELECT
+	bulletins.bulletin_date "Datos",
+	collected_date AS "Muestras",
+	bul.confirmed_cases + COALESCE(bul.probable_cases, 0)
+		AS "Oficial",
+	((bul.cumulative_confirmed_cases + COALESCE(bul.cumulative_probable_cases, 0))
+		- lag(bul.cumulative_confirmed_cases + COALESCE(bul.cumulative_probable_cases , 0), 7) OVER (
+		ORDER BY bio.collected_date
+	)) / 7.0 AS "Promedio",
+	bio.cases "Bioportal",
+	(bio.cumulative_cases - lag(bio.cumulative_cases, 7) OVER (
+		ORDER BY bio.collected_date
+	)) / 7.0 AS "Promedio",
+	first_infections "Primeros",
+	(cumulative_first_infections - lag(cumulative_first_infections, 7) OVER (
+		ORDER BY bio.collected_date
+	)) / 7.0 AS "Promedio",
+	possible_reinfections "Recontagios",
+	(cumulative_possible_reinfections - lag(cumulative_possible_reinfections, 7) OVER (
+		ORDER BY collected_date
+	)) / 7.0 AS "Promedio"
+FROM {{ ref('bioportal_encounters_agg') }} bio
+INNER JOIN bulletins
+	ON bulletins.bulletin_date = bio.bulletin_date
+LEFT OUTER JOIN {{ ref('bulletin_cases') }} bul
+	ON bul.bulletin_date = bulletins.bulletin_date
+	AND bul.datum_date = bio.collected_date
+ORDER BY collected_date DESC;

--- a/aws/athena-dbt/analysis/reinfections/antigen_strictness.sql
+++ b/aws/athena-dbt/analysis/reinfections/antigen_strictness.sql
@@ -1,0 +1,35 @@
+--
+-- Comparison between the case counts from the two followup test definitions.
+-- The "strict" definition is what UKHSA adopted on Feb. 1, 2022, which counts
+-- a positive test as a followup for the next 90 days after **any** positive
+-- test, antigen or PCR.
+--
+-- One criticism of this is that this 90 day criterion is much too strict
+-- for antigen tests, whose lower sentivity means they go negative soon after
+-- an episode, and that thus the strict definition will miss possible reinfections
+-- that we may reasonably spot through positive antigen tests.
+--
+WITH bulletins AS (
+	SELECT max(bulletin_date) AS bulletin_date
+	FROM covid19_puerto_rico_model.bioportal_curve
+)
+SELECT
+	bulletins.bulletin_date "Datos",
+	collected_date AS "Muestras",
+	bio.cases "Casos",
+	(bio.cumulative_cases - lag(bio.cumulative_cases, 7) OVER (
+		ORDER BY bio.collected_date
+	)) / 7.0 AS "Promedio",
+	bio.cases_strict "Casos (estricto)",
+	(bio.cumulative_cases_strict - lag(bio.cumulative_cases_strict, 7) OVER (
+		ORDER BY bio.collected_date
+	)) / 7.0 AS "Promedio",
+	bio.cases - bio.cases_strict "Diferencia",
+	((bio.cumulative_cases - bio.cumulative_cases_strict)
+		- lag(bio.cumulative_cases - bio.cumulative_cases_strict, 7) OVER (
+			ORDER BY bio.collected_date
+		)) / 7.0 AS "Promedio"
+FROM {{ ref('bioportal_encounters_agg') }} bio
+INNER JOIN bulletins
+	ON bulletins.bulletin_date = bio.bulletin_date
+ORDER BY collected_date DESC;

--- a/aws/athena-dbt/models/bioportal/encounters/bioportal_encounters_agg.sql
+++ b/aws/athena-dbt/models/bioportal/encounters/bioportal_encounters_agg.sql
@@ -4,6 +4,9 @@ SELECT
 	date_diff('day', collected_date, bulletin_date) age,
 	sum(encounters) encounters,
 	sum(cases) cases,
+	sum(cases_strict) cases_strict,
+	sum(first_infections) first_infections,
+	sum(possible_reinfections) possible_reinfections,
 	sum(rejections) rejections,
 	sum(antigens) antigens,
 	sum(molecular) molecular,
@@ -21,6 +24,18 @@ SELECT
 	    PARTITION BY bulletin_date
 	    ORDER BY collected_date
 	) AS cumulative_cases,
+	sum(sum(cases_strict)) OVER (
+	    PARTITION BY bulletin_date
+	    ORDER BY collected_date
+	) AS cumulative_cases_strict,
+	sum(sum(first_infections)) OVER (
+	    PARTITION BY bulletin_date
+	    ORDER BY collected_date
+	) AS cumulative_first_infections,
+	sum(sum(possible_reinfections)) OVER (
+	    PARTITION BY bulletin_date
+	    ORDER BY collected_date
+	) AS cumulative_possible_reinfections,
 	sum(sum(rejections)) OVER (
 	    PARTITION BY bulletin_date
 	    ORDER BY collected_date


### PR DESCRIPTION
Backend for improved followups/reinfections analysis, where we:

1. Shorten the followup period for antigen tests to 21 days (which I haven't calibrated all that well);
2. Calculate first infection and possible reinfection metrics, similar to how UKHSA now does.